### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ node app.js -- --host --port $PORT
 ```
 
 ### Windows
+
+1. Descarga `node.js` de la [página oficial](https://nodejs.org/es).
+2. Descarga este proyecto en tu computadora usando git o descargando el archivo con extensión `.zip` en este sitio.
+```sh
+git clone https://github.com/RamMaths/practicaRedes.git
+```
+3. Comprueba que tienes `node.js` instalado
+```sh
+node --version
+npm --version
+```
+4. Instala las dependencias
+```sh
+npm install
+```
+5. Corre el servidor en tu red local!
+```sh
+set PORT=8080
+node app.js
+```


### PR DESCRIPTION
Se modificó el README agregando una descripción de cómo se puede correr este servidor localmente haciendo uso de Windows, la diferencia se encuentra en la sintaxis que utiliza CMD de Windows por lo que se debe realizar de la siguiente manera:
`set PORT=8080`
`node app.js` 
